### PR TITLE
Add missing use statements in Image.php

### DIFF
--- a/contao/library/Contao/Image.php
+++ b/contao/library/Contao/Image.php
@@ -10,7 +10,12 @@
 
 namespace Contao;
 
+use Contao\Image\DeferredImageInterface;
 use Contao\Image\Image as NewImage;
+use Contao\Image\ImageDimensions;
+use Contao\Image\ImportantPart;
+use Contao\Image\ResizeConfiguration;
+use Contao\Image\ResizeOptions;
 use Imagine\Image\Box;
 use Symfony\Component\Filesystem\Path;
 use Zoglo\ContaoUserInterfaceBackport\Contao\CoreBundle\String\HtmlAttributes;


### PR DESCRIPTION
This fixes the following error when uploading an image for a product in Isotope, there are probably more cases where this causes issues.
Tested on Contao 4.13.50.

```
Symfony\Component\ErrorHandler\Error\ClassNotFoundError:
Attempted to load class "ImportantPart" from namespace "Contao".
Did you forget a "use" statement for "Contao\Image\ImportantPart"?

  at vendor/zoglo/contao-ui-backport/contao/library/Contao/Image.php:533
  at Contao\Image->prepareImportantPart()
     (vendor/zoglo/contao-ui-backport/contao/library/Contao/Image.php:481)
  at Contao\Image->prepareImage()
     (vendor/zoglo/contao-ui-backport/contao/library/Contao/Image.php:415)
  at Contao\Image->executeResize()
     (vendor/zoglo/contao-ui-backport/contao/library/Contao/Image.php:867)
  at Contao\Image::get('assets/images/p/example-image.png', 50, 50, 'box')
     (vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Widget/MediaManager.php:388)
  at Isotope\Widget\MediaManager->generate()
     (vendor/isotope/isotope-core/system/modules/isotope/library/Isotope/Backend.php:388)
  at Isotope\Backend->executePostActions('reloadMediaManager', object(DC_ProductData))
     (vendor/contao/core-bundle/src/Resources/contao/classes/Ajax.php:511)
  at Contao\Ajax->executePostActionsHook(object(DC_ProductData))
     (vendor/contao/core-bundle/src/Resources/contao/classes/Ajax.php:493)
  at Contao\Ajax->executePostActions(object(DC_ProductData))
     (vendor/contao/core-bundle/src/Resources/contao/classes/Backend.php:430)
  at Contao\Backend->getBackendModule('iso_products', null)
     (vendor/contao/core-bundle/src/Resources/contao/controllers/BackendMain.php:168)
  at Contao\BackendMain->run()
     (vendor/contao/core-bundle/src/Controller/BackendController.php:49)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:163)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:75)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public/index.php:44)                
```

Reference: https://github.com/contao/contao/blob/4.13/core-bundle/src/Resources/contao/library/Contao/Image.php